### PR TITLE
Configuration: rename inputs to metadata_sources

### DIFF
--- a/.dotnet-licenses.toml
+++ b/.dotnet-licenses.toml
@@ -5,7 +5,7 @@
 # This file describes the licenses of the files that are packaged in the resulting NuGet package.
 # Note that these are not necessarily all the licenses used by the project; only those related to the packaged files.
 
-inputs = [
+metadata_sources = [
     "DotNetLicenses/DotNetLicenses.fsproj"
 ]
 lock_file = ".dotnet-licenses.lock.toml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support the standard `--help` and `--version` command-line options.
 - Add configuration file support, the file path being passed through the command line.
 
-  Configuration file options available in this version: `inputs`, `overrides`, `lock_file`, and `package`.
+  Configuration file options available in this version: `metadata_sources`, `overrides`, `lock_file`, and `package`.
 - License lock file support for the packaged files.
 - Supported commands: `print` (default) and `generate-lock`.
 - Warnings and non-zero exit codes on duplicate and unused overrides.

--- a/DotNetLicenses.Tests/ConfigurationTests.fs
+++ b/DotNetLicenses.Tests/ConfigurationTests.fs
@@ -14,7 +14,7 @@ open Xunit
 [<Fact>]
 let ``Configuration should be read correctly``(): Task = task {
     let content = """
-inputs = [
+metadata_sources = [
   "File.csproj",
   "File.fsproj",
 ]
@@ -27,7 +27,7 @@ package = [
     use input = new MemoryStream(Encoding.UTF8.GetBytes content)
     let! configuration = Configuration.Read(input, Some "<test>")
     Assert.Equal({
-        Inputs = [|
+        MetadataSources = [|
             "File.csproj"
             "File.fsproj"
         |]
@@ -43,7 +43,7 @@ package = [
 [<Fact>]
 let ``Metadata overrides should be read correctly``(): Task = task {
     let content = """
-inputs = ["File.csproj"]
+metadata_sources = ["File.csproj"]
 overrides = [
     { id = "Package1", version = "1.0.0", spdx = "MIT", copyright = "" },
     { id = "Package1", version = "2.0.0", spdx = "MIT", copyright = "Copyright1" }
@@ -53,7 +53,7 @@ overrides = [
     let! configuration = Configuration.Read(input, Some "<test>")
     Assert.Equal({
         Configuration.Empty with
-            Inputs = [| "File.csproj" |]
+            MetadataSources = [| "File.csproj" |]
             Overrides = [|
                 {
                     Id = "Package1"
@@ -74,7 +74,7 @@ overrides = [
 [<Fact>]
 let ``GetOverrides works on duplicate package names (not versions)``(): Task = task {
     let content = """
-inputs = []
+metadata_sources = []
 overrides = [
     { id = "Package1", version = "1.0.0", spdx = "MIT", copyright = "" },
     { id = "Package2", version = "1.0.0", spdx = "MIT", copyright = "Copyright1" }
@@ -95,7 +95,7 @@ overrides = [
 [<Fact>]
 let ``GetOverrides prints a warning on duplicate keys``(): Task = task {
     let content = """
-inputs = []
+metadata_sources = []
 overrides = [
     { id = "Package1", version = "1.0.0", spdx = "MIT", copyright = "" },
     { id = "Package1", version = "1.0.0", spdx = "MIT", copyright = "Copyright1" }

--- a/DotNetLicenses.Tests/ProcessorTests.fs
+++ b/DotNetLicenses.Tests/ProcessorTests.fs
@@ -14,7 +14,7 @@ open Xunit
 type private Runner =
     static member RunFunction(func: _ * _ * _ * _ -> Task, config, ?baseDirectory: string) = task {
         let baseDirectory =
-            baseDirectory |> Option.defaultWith(fun() -> Path.GetDirectoryName(Seq.exactlyOne config.Inputs))
+            baseDirectory |> Option.defaultWith(fun() -> Path.GetDirectoryName(Seq.exactlyOne config.MetadataSources))
         let wp = WarningProcessor()
         do! func(
             config,
@@ -32,7 +32,7 @@ let private runGenerator t = Runner.RunFunction(Processor.GenerateLockFile, t)
 let ``Generator produces an error if no lock file is defined``(): Task = task {
     let config = {
         Configuration.Empty with
-            Inputs = [|"non-important.csproj"|]
+            MetadataSources = [|"non-important.csproj"|]
             LockFile = null
     }
     let! wp = runGenerator config
@@ -46,7 +46,7 @@ let ``Generator produces an error if no package contents are defined``(): Task =
     try
         let config = {
             Configuration.Empty with
-                Inputs = [|"non-important.csproj"|]
+                MetadataSources = [|"non-important.csproj"|]
                 LockFile = lockFile
         }
         let! wp = runGenerator config
@@ -61,7 +61,7 @@ let ``Printer generates warnings if there are stale overrides``(): Task =
     DataFiles.Deploy "Test.csproj" (fun project -> task {
         let config = {
             Configuration.Empty with
-                Inputs = [|project|]
+                MetadataSources = [|project|]
                 Overrides = [|{
                     Id = "NonExistent"
                     Version = ""
@@ -83,7 +83,7 @@ let ``Printer generates no warnings on a valid config``(): Task =
     DataFiles.Deploy "Test.csproj" (fun project -> task {
         let config = {
             Configuration.Empty with
-                Inputs = [|project|]
+                MetadataSources = [|project|]
                 LockFile = "lock.toml"
         }
         let! wp = runPrinter config
@@ -105,7 +105,7 @@ copyright = "Copyright FVNever.DotNetLicenses"
 """
     let config = {
         Configuration.Empty with
-            Inputs = [| project |]
+            MetadataSources = [| project |]
             LockFile = Path.GetTempFileName()
             Package = [|
                 { Type = "directory"; Path = directory.Path }
@@ -136,7 +136,7 @@ copyright = "Copyright FVNever.DotNetLicenses"
         let lockFile = Path.Combine(directory.Path, "lock.toml")
         let config = {
             Configuration.Empty with
-                Inputs = [| project |]
+                MetadataSources = [| project |]
                 LockFile = lockFile
                 Package = [|
                     { Type = "directory"; Path = directory.Path }
@@ -167,7 +167,7 @@ copyright = "Copyright FVNever.DotNetLicenses"
         let lockFile = Path.Combine(directory.Path, "lock.toml")
         let config = {
             Configuration.Empty with
-                Inputs = [| project |]
+                MetadataSources = [| project |]
                 LockFile = lockFile
                 Package = [|
                     { Type = "zip"; Path = Path.GetFileName archivePath }
@@ -194,7 +194,7 @@ let ``Processor processes ZIP files using a glob pattern``(): Task = task {
         let lockFile = Path.Combine(directory.Path, "lock.toml")
         let config = {
             Configuration.Empty with
-                Inputs = [| project |]
+                MetadataSources = [| project |]
                 LockFile = lockFile
                 Package = [|
                     { Type = "zip"; Path = archiveGlob }
@@ -214,7 +214,7 @@ let ``Lock file generator produces a warning if it's unable to find a license fo
     do! File.WriteAllTextAsync(packagedFile, "Hello World!")
     let config = {
         Configuration.Empty with
-            Inputs = [||]
+            MetadataSources = [||]
             LockFile = Path.Combine(directory.Path, "lock.toml")
             Package = [|
                 { Type = "directory"; Path = directory.Path }

--- a/DotNetLicenses/Configuration.fs
+++ b/DotNetLicenses/Configuration.fs
@@ -14,14 +14,14 @@ open Tomlyn
 [<CLIMutable>]
 type Configuration =
     {
-        Inputs: string[]
+        MetadataSources: string[]
         [<CanBeNull>] Overrides: Override[]
         [<CanBeNull>] LockFile: string
         [<CanBeNull>] Package: PackageSpec[]
     }
 
     static member Empty = {
-        Inputs = Array.empty
+        MetadataSources = Array.empty
         Overrides = null
         LockFile = null
         Package = null

--- a/DotNetLicenses/Processor.fs
+++ b/DotNetLicenses/Processor.fs
@@ -42,7 +42,7 @@ let private CollectMetadata (config: Configuration) baseFolderPath nuGet wp = ta
     let mutable usedOverrides = Set.empty
 
     let metadataList = ResizeArray()
-    for relativeProjectPath in config.Inputs do
+    for relativeProjectPath in config.MetadataSources do
         let projectPath = Path.Combine(baseFolderPath, relativeProjectPath)
         let! metadata = reader.ReadFromProject(projectPath, overrides)
         usedOverrides <- Set.union usedOverrides metadata.UsedOverrides

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Configuration
 -------------
 The configuration file format is TOML. The format:
 ```toml
-inputs = [ # required
+metadata_sources = [ # required
   "path/to/project1.csproj",
   "path/to/project2.csproj"
 ]
@@ -61,7 +61,7 @@ package = [ # required for generate-lock
     { type = "zip", path = "bin/*.zip" }
 ]
 ```
-The `inputs` parameter (required) is a list of paths to the projects to analyze. The paths are either absolute or relative to the directory containing the configuration file.
+The `metadata_sources` parameter (required) is a list of paths to the projects to analyze. The paths are either absolute or relative to the directory containing the configuration file.
 
 The `overrides` parameter (optional) should contain a set of license overrides for incorrectly marked packages in NuGet. Every record contains string fields `id`, `version`, `spdx`, and `copyright`. All fields are mandatory.
 


### PR DESCRIPTION
So, I am starting the configuration overhaul and improving the naming to correspond to the core concepts better.