### PR TITLE
Extract license for the project from REUSE

### DIFF
--- a/.dotnet-licenses.lock.toml
+++ b/.dotnet-licenses.lock.toml
@@ -1,3 +1,4 @@
+# REUSE-IgnoreStart
 "_rels/.rels" = [{spdx = ["MIT"], copyright = ["2024 Friedrich von Never <friedrich@fornever.me>"]}]
 "[Content_Types].xml" = [{spdx = ["MIT"], copyright = ["2024 Friedrich von Never <friedrich@fornever.me>"]}]
 "*.nuspec" = [{spdx = ["MIT"], copyright = ["2024 Friedrich von Never <friedrich@fornever.me>"]}]
@@ -43,3 +44,4 @@
 "tools/net8.0/any/TruePath.dll" = [{source_id = "TruePath", source_version = "1.1.0", spdx = ["MIT"], copyright = ["© 2024 Friedrich von Never"]}]
 "tools/net8.0/any/zh-Hans/FSharp.Core.resources.dll" = [{source_id = "FSharp.Core", source_version = "8.0.200", spdx = ["MIT"], copyright = ["© Microsoft Corporation. All rights reserved."]}]
 "tools/net8.0/any/zh-Hant/FSharp.Core.resources.dll" = [{source_id = "FSharp.Core", source_version = "8.0.200", spdx = ["MIT"], copyright = ["© Microsoft Corporation. All rights reserved."]}]
+# REUSE-IgnoreEnd

--- a/.dotnet-licenses.toml
+++ b/.dotnet-licenses.toml
@@ -7,18 +7,21 @@
 
 metadata_sources = [
     { type = "nuget", include = "DotNetLicenses.sln" },
-    { type = "license", spdx = "MIT", copyright = "2024 Friedrich von Never <friedrich@fornever.me>", patterns_covered = [
+    { type = "reuse", root = ".", patterns_covered = [
         { type = "nuget" },
         { type = "msbuild", include = "DotNetLicenses.sln" }
-    ] },
-    { type = "reuse", root = "." }
+    ] }
 ]
+
+# REUSE-IgnoreStart
 metadata_overrides = [
     { id = "GitignoreParserNet", version = "0.2.0.12", spdx = "Apache-2.0", copyright = [
         "Copyright (c) 2021 Gyuirgy",
         "Copyright 2014 codemix ltd."
     ] }
 ]
+# REUSE-IgnoreEnd
+
 lock_file = ".dotnet-licenses.lock.toml"
 packaged_files = [
     { type = "zip", path = "DotNetLicenses/bin/Release/FVNever.DotNetLicenses.0.0.0.nupkg" }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 2024 Friedrich von Never <friedrich@fornever.me>
+# SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
 #
 # SPDX-License-Identifier: MIT
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
 
 SPDX-License-Identifier: MIT
+
+REUSE-IgnoreStart
 -->
 
 Contributor Guide
@@ -76,6 +78,8 @@ If the automation asks you to update the copyright years in certain files, eithe
 ```console
 $ pwsh -File scripts/Test-LicenseHeaders.ps1 -AutoFix
 ```
+
+<!-- REUSE-IgnoreEnd -->
 
 [dotnet-sdk]: https://dotnet.microsoft.com/en-us/download
 [powershell]: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,12 @@ SPDX-License-Identifier: MIT
         <Version>0.0.0</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <!-- TODO[#5]: Automate this using reuse -->
+        <!-- REUSE-IgnoreStart -->
         <Copyright>
 © 2024 Friedrich von Never;
 © Microsoft Corporation. All rights reserved. <!-- This is from FSharp.Core -->
         </Copyright>
+        <!-- REUSE-IgnoreEnd -->
     </PropertyGroup>
 
     <PropertyGroup Label="Build">

--- a/DotNetLicenses.TestFramework/PackageSpecs.fs
+++ b/DotNetLicenses.TestFramework/PackageSpecs.fs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.md>
+// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
 //
 // SPDX-License-Identifier: MIT
 

--- a/DotNetLicenses.Tests/IgnoresTests.fs
+++ b/DotNetLicenses.Tests/IgnoresTests.fs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.md>
+// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
 //
 // SPDX-License-Identifier: MIT
 

--- a/DotNetLicenses.Tests/LockFileTests.fs
+++ b/DotNetLicenses.Tests/LockFileTests.fs
@@ -25,9 +25,11 @@ let ``LockFile should be have expected format``(): Task =
         LocalPathPattern "a.txt", item "a"
     |]
 
-    let expectedContent = """"a.txt" = [{source_id = "a", source_version = "1.0.0", spdx = ["MIT"], copyright = ["none"]}]
+    let expectedContent = """# REUSE-IgnoreStart
+"a.txt" = [{source_id = "a", source_version = "1.0.0", spdx = ["MIT"], copyright = ["none"]}]
 "x.txt" = [{source_id = "a", source_version = "1.0.0", spdx = ["MIT"], copyright = ["none"]}, {source_id = "b", source_version = "1.0.0", spdx = ["MIT"], copyright = ["none"]}]
 "y.txt" = [{source_id = "a", source_version = "1.0.0", spdx = ["MIT"], copyright = ["none"]}]
+# REUSE-IgnoreEnd
 """
     task {
         let lockFilePath = AbsolutePath(Path.GetTempFileName())

--- a/DotNetLicenses.Tests/MetadataTests.fs
+++ b/DotNetLicenses.Tests/MetadataTests.fs
@@ -11,6 +11,8 @@ open DotNetLicenses.NuGet
 open DotNetLicenses.TestFramework
 open Xunit
 
+// REUSE-IgnoreStart
+
 [<Fact>]
 let ``Get metadata from .nuspec works correctly``(): Task = task {
     let path = DataFiles.Get "Test1.nuspec"
@@ -50,3 +52,5 @@ let ``Overrides work as expected``(): Task = task {
     |], metadata.Items)
     Assert.Equivalent([| { PackageId = "FVNever.Package1"; Version = "0.0.0" } |], metadata.UsedOverrides)
 }
+
+// REUSE-IgnoreEnd

--- a/DotNetLicenses.Tests/NuGetTests.fs
+++ b/DotNetLicenses.Tests/NuGetTests.fs
@@ -13,6 +13,8 @@ open DotNetLicenses.TestFramework
 open TruePath
 open Xunit
 
+// REUSE-IgnoreStart
+
 [<Fact>]
 let ``NuSpec file path should be determined correctly``(): unit =
     let nuGetPackagesRootPath = PackagesFolderPath
@@ -92,3 +94,5 @@ let ``NuGet reads transitive package references correctly``(): Task =
             { PackageId = "YamlDotNet";  Version = "15.1.1" }
         |], references)
     })
+
+// REUSE-IgnoreEnd

--- a/DotNetLicenses.Tests/ProcessorTests.fs
+++ b/DotNetLicenses.Tests/ProcessorTests.fs
@@ -12,6 +12,8 @@ open DotNetLicenses.TestFramework
 open TruePath
 open Xunit
 
+// REUSE-IgnoreStart
+
 type private Runner =
     static member RunFunction(func: _ * _ * _ * _ -> Task, config, ?baseDirectory: AbsolutePath) = task {
         let baseDirectory =
@@ -443,3 +445,5 @@ let ``Package cover spec works``(): Task =
         let! actualContent = File.ReadAllTextAsync <| (baseDir / (Option.get config.LockFile)).Value
         Assert.Equal(expectedLock.ReplaceLineEndings "\n", actualContent.ReplaceLineEndings "\n")
     })
+
+// REUSE-IgnoreEnd

--- a/DotNetLicenses.Tests/ProcessorTests.fs
+++ b/DotNetLicenses.Tests/ProcessorTests.fs
@@ -12,8 +12,6 @@ open DotNetLicenses.TestFramework
 open TruePath
 open Xunit
 
-// REUSE-IgnoreStart
-
 type private Runner =
     static member RunFunction(func: _ * _ * _ * _ -> Task, config, ?baseDirectory: AbsolutePath) = task {
         let baseDirectory =
@@ -361,6 +359,7 @@ let ``Combined licenses from REUSE source work``(): Task = task {
     let myMitFile = directory.Path / "package" / "my-mit-file.txt"
     let myCombinedFile = directory.Path / "package" / "my-combined-file.txt"
 
+    // REUSE-IgnoreStart
     let mitFileContent = """SPDX-FileCopyrightText: 2024 Me
 SPDX-License-Identifier: MIT
 text
@@ -390,6 +389,8 @@ text
     """)
 
     do! File.WriteAllTextAsync((directory.Path / "source" / ".gitignore").Value, "/my-cc-by-3-file.txt")
+
+    // REUSE-IgnoreEnd
 
     let expectedLock = """# REUSE-IgnoreStart
 "my-combined-file.txt" = [{spdx = ["CC-BY-1.0", "CC-BY-4.0", "CC-0", "MIT"], copyright = ["2024 Me"]}]
@@ -461,5 +462,3 @@ let ``Package cover spec works``(): Task =
         let! actualContent = File.ReadAllTextAsync <| (baseDir / (Option.get config.LockFile)).Value
         Assert.Equal(expectedLock.ReplaceLineEndings "\n", actualContent.ReplaceLineEndings "\n")
     })
-
-// REUSE-IgnoreEnd

--- a/DotNetLicenses.Tests/ProcessorTests.fs
+++ b/DotNetLicenses.Tests/ProcessorTests.fs
@@ -107,7 +107,9 @@ let ``Processor generates a lock file``(): Task = DataFiles.Deploy "Test.csproj"
     use directory = DisposableDirectory.Create()
     do! File.WriteAllTextAsync((directory.Path / "test.txt").Value, "Hello!")
 
-    let expectedLock = """"test.txt" = [{source_id = "FVNever.DotNetLicenses", source_version = "1.0.0", spdx = ["License FVNever.DotNetLicenses"], copyright = ["Copyright FVNever.DotNetLicenses"]}]
+    let expectedLock = """# REUSE-IgnoreStart
+"test.txt" = [{source_id = "FVNever.DotNetLicenses", source_version = "1.0.0", spdx = ["License FVNever.DotNetLicenses"], copyright = ["Copyright FVNever.DotNetLicenses"]}]
+# REUSE-IgnoreEnd
 """
     let config = {
         Configuration.Empty with
@@ -131,7 +133,9 @@ let ``Processor generates a lock file for a file tree``(): Task = task {
     use directory = DisposableDirectory.Create()
     let packagedFile = directory.Path / "my-file.txt"
     do! File.WriteAllTextAsync(packagedFile.Value, "Hello World!")
-    let expectedLock = """"my-file.txt" = [{source_id = "FVNever.DotNetLicenses", source_version = "1.0.0", spdx = ["License FVNever.DotNetLicenses"], copyright = ["Copyright FVNever.DotNetLicenses"]}]
+    let expectedLock = """# REUSE-IgnoreStart
+"my-file.txt" = [{source_id = "FVNever.DotNetLicenses", source_version = "1.0.0", spdx = ["License FVNever.DotNetLicenses"], copyright = ["Copyright FVNever.DotNetLicenses"]}]
+# REUSE-IgnoreEnd
 """
 
     do! DataFiles.Deploy "Test.csproj" (fun project -> task {
@@ -159,7 +163,9 @@ let ``Processor generates a lock file for a ZIP archive``(): Task = task {
     use directory = DisposableDirectory.Create()
     let archivePath = directory.Path / "file.zip"
     ZipFiles.SingleFileArchive(archivePath, "content/my-file.txt", "Hello World"B)
-    let expectedLock = """"content/my-file.txt" = [{source_id = "FVNever.DotNetLicenses", source_version = "1.0.0", spdx = ["License FVNever.DotNetLicenses"], copyright = ["Copyright FVNever.DotNetLicenses"]}]
+    let expectedLock = """# REUSE-IgnoreStart
+"content/my-file.txt" = [{source_id = "FVNever.DotNetLicenses", source_version = "1.0.0", spdx = ["License FVNever.DotNetLicenses"], copyright = ["Copyright FVNever.DotNetLicenses"]}]
+# REUSE-IgnoreEnd
 """
     do! DataFiles.Deploy "Test.csproj" (fun project -> task {
         let lockFile = directory.Path / "lock.toml"
@@ -230,7 +236,9 @@ let ``License metadata gets saved to the lock file``(): Task = task {
     let packagedFile = directory.Path / "my-file.txt"
     do! File.WriteAllTextAsync(packagedFile.Value, "")
 
-    let expectedLock = """"my-file.txt" = [{spdx = ["MIT"], copyright = ["Me"]}]
+    let expectedLock = """# REUSE-IgnoreStart
+"my-file.txt" = [{spdx = ["MIT"], copyright = ["Me"]}]
+# REUSE-IgnoreEnd
 """
 
     let lockFile = directory.Path / "lock.toml"
@@ -271,7 +279,9 @@ text
     do! File.WriteAllTextAsync(packagedFile.Value, fileContent)
     do! File.WriteAllTextAsync(sourceFile.Value, fileContent)
 
-    let expectedLock = """"my-file.txt" = [{spdx = ["MIT"], copyright = ["2024 Me"]}]
+    let expectedLock = """# REUSE-IgnoreStart
+"my-file.txt" = [{spdx = ["MIT"], copyright = ["2024 Me"]}]
+# REUSE-IgnoreEnd
 """
 
     let lockFile = directory.Path / "lock.toml"
@@ -315,7 +325,9 @@ Copyright: 2024 Me
 License: MIT
     """)
 
-    let expectedLock = """"my-file.txt" = [{spdx = ["MIT"], copyright = ["2024 Me"]}]
+    let expectedLock = """# REUSE-IgnoreStart
+"my-file.txt" = [{spdx = ["MIT"], copyright = ["2024 Me"]}]
+# REUSE-IgnoreEnd
 """
 
     let lockFile = directory.Path / "lock.toml"
@@ -379,8 +391,10 @@ text
 
     do! File.WriteAllTextAsync((directory.Path / "source" / ".gitignore").Value, "/my-cc-by-3-file.txt")
 
-    let expectedLock = """"my-combined-file.txt" = [{spdx = ["CC-BY-1.0", "CC-BY-4.0", "CC-0", "MIT"], copyright = ["2024 Me"]}]
+    let expectedLock = """# REUSE-IgnoreStart
+"my-combined-file.txt" = [{spdx = ["CC-BY-1.0", "CC-BY-4.0", "CC-0", "MIT"], copyright = ["2024 Me"]}]
 "my-mit-file.txt" = [{spdx = ["MIT"], copyright = ["2024 Me"]}]
+# REUSE-IgnoreEnd
 """
 
     let lockFile = directory.Path / "lock.toml"
@@ -435,7 +449,9 @@ let ``Package cover spec works``(): Task =
         }
 
         do! File.WriteAllTextAsync(targetAssembly.Value, "Test file")
-        let expectedLock = """"Test.dll" = [{spdx = ["MIT"], copyright = ["Package cover spec works"]}]
+        let expectedLock = """# REUSE-IgnoreStart
+"Test.dll" = [{spdx = ["MIT"], copyright = ["Package cover spec works"]}]
+# REUSE-IgnoreEnd
 """
 
         let! wp = Runner.RunFunction(Processor.GenerateLockFile, config, baseDirectory = baseDir)

--- a/DotNetLicenses.Tests/ProcessorTests.fs
+++ b/DotNetLicenses.Tests/ProcessorTests.fs
@@ -270,10 +270,12 @@ let ``Basic REUSE specification works``(): Task = task {
     let sourceFile = directory.Path / "source" / "my-file.txt"
     let packagedFile = directory.Path / "package" / "my-file.txt"
 
+    // REUSE-IgnoreStart
     let fileContent = """SPDX-FileCopyrightText: 2024 Me
 SPDX-License-Identifier: MIT
 text
 """
+    // REUSE-IgnoreEnd
     do! File.WriteAllTextAsync(packagedFile.Value, fileContent)
     do! File.WriteAllTextAsync(sourceFile.Value, fileContent)
 

--- a/DotNetLicenses/Ignores.fs
+++ b/DotNetLicenses/Ignores.fs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.md>
+// SPDX-FileCopyrightText: 2024 Friedrich von Never <friedrich@fornever.me>
 //
 // SPDX-License-Identifier: MIT
 

--- a/DotNetLicenses/LockFile.fs
+++ b/DotNetLicenses/LockFile.fs
@@ -31,5 +31,5 @@ let SaveLockFile(path: AbsolutePath, items: LockFileEntry seq): Task =
             list.Add item
             dictionary.Add(pattern.Value, list)
 
-    let text = Toml.FromModel dictionary
+    let text = "# REUSE-IgnoreStart\n" + Toml.FromModel dictionary + "# REUSE-IgnoreEnd\n"
     File.WriteAllTextAsync(path.Value, text)

--- a/ReuseSpec/ReuseDirectory.cs
+++ b/ReuseSpec/ReuseDirectory.cs
@@ -52,7 +52,11 @@ public static class ReuseDirectory
         }
 
         var gitDirectory = directory / ".git";
-        return allFiles.Where(file => !file.Value.StartsWith(gitDirectory.Value)).ToList();
+        return allFiles
+            .Where(file => !file.Value.StartsWith(gitDirectory.Value)
+                           && file.FileName != "LICENSE.txt"
+                           && file.Parent?.FileName != "LICENSES") // TODO: Verify with the spec
+            .ToList();
     }
 
     private static async Task<List<DebianCopyrightFilesEntry>> ReadDep5File(AbsolutePath directory)

--- a/ReuseSpec/ReuseDirectory.cs
+++ b/ReuseSpec/ReuseDirectory.cs
@@ -55,7 +55,7 @@ public static class ReuseDirectory
         return allFiles
             .Where(file => !file.Value.StartsWith(gitDirectory.Value)
                            && file.FileName != "LICENSE.txt"
-                           && file.Parent?.FileName != "LICENSES") // TODO: Verify with the spec
+                           && file.Parent?.FileName != "LICENSES") // TODO[#46]: Verify with the spec
             .ToList();
     }
 

--- a/ReuseSpec/ReuseFileEntry.cs
+++ b/ReuseSpec/ReuseFileEntry.cs
@@ -41,7 +41,7 @@ public record ReuseFileEntry(
 
     private static IEnumerable<string> FilterIgnoredBlocks(IEnumerable<string> input)
     {
-        var ignoring = false;  // TODO: Should we support nested ignore/unignore blocks?
+        var ignoring = false;  // TODO[#46]: Should we support nested ignore/unignore blocks?
         foreach (var line in input)
         {
             if (line.Contains("REUSE-IgnoreStart"))

--- a/ReuseSpec/ReuseFileEntry.cs
+++ b/ReuseSpec/ReuseFileEntry.cs
@@ -41,7 +41,7 @@ public record ReuseFileEntry(
 
     private static IEnumerable<string> FilterIgnoredBlocks(IEnumerable<string> input)
     {
-        var ignoring = false;
+        var ignoring = false;  // TODO: Should we support nested ignore/unignore blocks?
         foreach (var line in input)
         {
             if (line.Contains("REUSE-IgnoreStart"))

--- a/ReuseSpec/ReuseFileEntry.cs
+++ b/ReuseSpec/ReuseFileEntry.cs
@@ -63,6 +63,8 @@ public record ReuseFileEntry(
         }
     }
 
+    // REUSE-IgnoreStart
+
     private static readonly Regex[] CopyrightPatterns = [
         new(@"SPDX-(?:File|Snippet)CopyrightText:\s*(.*)"),
         new(@"Copyright\s?(?:\([Cc]\))\s+(.*)"),
@@ -108,6 +110,8 @@ public record ReuseFileEntry(
 
         return new ReuseCombinedEntry([..licenses], [..copyrights]);
     }
+
+    // REUSE-IgnoreEnd
 }
 
 public record ReuseCombinedEntry(

--- a/scripts/Test-LicenseHeaders.ps1
+++ b/scripts/Test-LicenseHeaders.ps1
@@ -15,6 +15,8 @@ param (
     [switch] $Autofix
 )
 
+# REUSE-IgnoreStart
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -102,3 +104,5 @@ try {
 } finally {
     Pop-Location
 }
+
+# REUSE-IgnoreEnd


### PR DESCRIPTION
This also fixes various small issues I noted while doing this.

The tool is now officially self-bootstrapped.