### PR TITLE
Fix path prefix calculation issues

### DIFF
--- a/DotNetLicenses.Tests/CoveragePatternTests.fs
+++ b/DotNetLicenses.Tests/CoveragePatternTests.fs
@@ -99,7 +99,7 @@ let ``NuGet coverage pattern collector works``(): Task = task {
     for entry in sourceEntries do
         let! result = CollectCoveredFileLicense directory.Path coverageCache hashCache [| metadata |] entry
         let pattern =
-            if entry.SourceRelativePath.StartsWith("package/services/metadata/core-properties")
+            if entry.SourceRelativePath.StartsWith("package/services/metadata/core-properties/")
             then "package/services/metadata/core-properties/*.psmdcp"
             else entry.SourceRelativePath
             |> LocalPathPattern

--- a/ReuseSpec/ReuseDirectory.cs
+++ b/ReuseSpec/ReuseDirectory.cs
@@ -54,7 +54,7 @@ public static class ReuseDirectory
 
         var gitDirectory = directory / ".git";
         return allFiles
-            .Where(file => !file.Value.StartsWith(gitDirectory.Value)
+            .Where(file => !file.Value.StartsWith(gitDirectory.Value + Path.PathSeparator)
                            && file.FileName != "LICENSE.txt"
                            && file.Parent?.FileName != "LICENSES") // TODO[#46]: Verify with the spec
             .ToList();


### PR DESCRIPTION
In several places, we are checking if certain paths have some prefix. We were doing it incorrectly: say, `.gitignore` would be filtered out by out filter on `.git`.

Now, this is fixed.